### PR TITLE
fix overflow on 32-bit platforms

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,5 +52,15 @@ jobs:
       - name: Toolchain setup
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Check
+      - name: Test
         run: cargo test --locked --all-features --all-targets
+
+  test-32-bit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: taiki-e/install-action@cross
+
+      - name: Test
+        run: cross test --release --target i686-unknown-linux-gnu

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,7 +141,7 @@ fn parse_varint(first_input: &[u8]) -> IResult<&[u8], Option<usize>> {
     //
     // In 32-bit plaforms, the conversion from u64 to usize will fail if the value
     // is bigger than u32::MAX.
-    let result = (value != bitmask).then_some(value.try_into()?);
+    let result = (value != bitmask).then(|| value.try_into()).transpose()?;
 
     Ok((input, result))
 }


### PR DESCRIPTION
While working on the website, I noticed a strange behavior on WASM, which is 32-bit.

Traced it down to an overflow. Here I fix this and avoid it happening again in the future by also running tests for 32-bit.